### PR TITLE
Add dajaxice to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-htmlmin==0.5.1
 django-kombu==0.9.4
 django-pylibmc-sasl==0.2.4
 django-storages==1.1.4
+django-dajaxice==0.2
 Fabric==1.4.0
 gunicorn==0.14.1
 newrelic==1.1.0.192


### PR DESCRIPTION
It is used in settings/common.py but it's not in requirements which leads into an error when trying to run any commands with manage.py.
