### PR TITLE
Split requirements between production and development

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -1,0 +1,9 @@
+boto==2.2.2
+Django==1.3.1
+django-celery==2.5.1
+django-htmlmin==0.5.1
+django-kombu==0.9.4
+django-storages==1.1.4
+django-dajaxice==0.2
+South==0.7.3
+Sphinx==1.1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+-r common-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,7 @@
-boto==2.2.2
-Django==1.3.1
-django-celery==2.5.1
-django-htmlmin==0.5.1
-django-kombu==0.9.4
-django-pylibmc-sasl==0.2.4
-django-storages==1.1.4
-django-dajaxice==0.2
+-r common-requirements.txt
 Fabric==1.4.0
 gunicorn==0.14.1
 newrelic==1.1.0.192
 psycopg2==2.4.4
 pylibmc==1.2.2
-South==0.7.3
-Sphinx==1.1.2
+django-pylibmc-sasl==0.2.4


### PR DESCRIPTION
This patch introduces a new schema for requirements files:
common-requirements.txt (requirements that the project can't start at all without)
requirements.txt (must be like this since this is what Heroku etc expects to be found; pulls in common-requirements.txt and then overrides things from it)
dev-requirements.txt (pulls in common-requirements.txt and then adds development stuff into it. the reason this exists at all is that you might want to have eg pyflakes or unittesting dependencies be installed on the development machine but not in production server)
