### PR TITLE
The new-style thing is to use the same wsgi application in the Django project always

### DIFF
--- a/project_name/settings/common.py
+++ b/project_name/settings/common.py
@@ -239,3 +239,6 @@ CELERY_TASK_RESULT_EXPIRES = timedelta(minutes=30)
 # See: http://ask.github.com/django-celery/
 setup_loader()
 ########## END CELERY CONFIGURATION
+
+# Python dotted path to the WSGI application used by Django's runserver.
+WSGI_APPLICATION = '{{ project_name }}.wsgi.application'


### PR DESCRIPTION
The earlier changes only pulled it in but having read documentation, you apparently need to set a configuration variable WSGI_APPLICATION as well so this commit includes that.
