### PR TITLE
Set django-compressor==1.2a2 instead of '==dev'

### DIFF
--- a/reqs/common.txt
+++ b/reqs/common.txt
@@ -1,6 +1,6 @@
 Django==1.4
 django-celery==2.5.5
-django-compressor==dev
+django-compressor==1.2a2
 Fabric==1.4.2
 South==0.7.5
 Sphinx==1.1.3


### PR DESCRIPTION
See issue #10.

I don't believe this was a local problem. Maybe pip can't find dev? 
