### PR TITLE
Use a range for django version in requirements

### DIFF
--- a/reqs/common.txt
+++ b/reqs/common.txt
@@ -1,4 +1,4 @@
-Django==1.4.2
+Django>=1.4.0,<=1.4.9
 django-celery==3.0.11
 django-compressor==1.2
 Fabric==1.4.3


### PR DESCRIPTION
This ensures new minor releases are installed, which shouldn't pose compatibility issues.
