### PR TITLE
Update the memcache addon

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -11,7 +11,7 @@ HEROKU_ADDONS = (
     'cloudamqp:lemur',
     'heroku-postgresql:dev',
     'scheduler:standard',
-    'memcache:5mb',
+    'memcachier:dev',
     'newrelic:standard',
     'pgbackups:auto-month',
     'sentry:developer',


### PR DESCRIPTION
Because the `memcache:5mb` has been disabled on Heroku.
