### PR TITLE
Added CELERY_CHORD_PROPAGATES = True

### DIFF
--- a/project_name/settings/common.py
+++ b/project_name/settings/common.py
@@ -245,6 +245,9 @@ LOGGING = {
 # See: http://celery.readthedocs.org/en/latest/configuration.html#celery-task-result-expires
 CELERY_TASK_RESULT_EXPIRES = timedelta(minutes=30)
 
+# See: http://docs.celeryproject.org/en/master/configuration.html#std:setting-CELERY_CHORD_PROPAGATES
+CELERY_CHORD_PROPAGATES = True
+
 # See: http://celery.github.com/celery/django/
 setup_loader()
 ########## END CELERY CONFIGURATION


### PR DESCRIPTION
This is a questionable pull request because in the next version of 3.1, celery will make this the default anyway. This pull request will be obsolete once that version of celery is released but that still might be a while.

That said, this change will prepare new users of django-skel for the new version of celery.
