### PR TITLE
AWS_EXPIREY is an incorrect spelling. Changed to AWS_EXPIRY

### DIFF
--- a/project_name/settings/prod.py
+++ b/project_name/settings/prod.py
@@ -95,10 +95,10 @@ AWS_AUTO_CREATE_BUCKET = True
 AWS_QUERYSTRING_AUTH = False
 
 # AWS cache settings, don't change unless you know what you're doing:
-AWS_EXPIREY = 60 * 60 * 24 * 7
+AWS_EXPIRY = 60 * 60 * 24 * 7
 AWS_HEADERS = {
-    'Cache-Control': 'max-age=%d, s-maxage=%d, must-revalidate' % (AWS_EXPIREY,
-        AWS_EXPIREY)
+    'Cache-Control': 'max-age=%d, s-maxage=%d, must-revalidate' % (AWS_EXPIRY,
+        AWS_EXPIRY)
 }
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url


### PR DESCRIPTION
I was browsing through your very nice skeleton project and I notice that there was a setting in `prod.py` that was incorrectly spelled. 

`AWS_EXPIREY` should have been `AWS_EXPIRY`; this PR fixes that.
