### PR TITLE
Updated getting-started.rst

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -26,7 +26,7 @@ project.
 Next, create your first django app for this project::
 
     $ mkdir woot/apps/myapp
-    $ python manage.py startapp myapp woot/apps/myapp
+    $ django-admin.py startapp myapp woot/apps/myapp
 
 Lastly, create a Git repository for your new project, and commit everything::
 


### PR DESCRIPTION
I've updated instructions because calling `python manage.py` raises `ImportError: Could not import settings 'woot.settings.dev' (Is it on sys.path?): No module named djcelery`. Calling `django-admin.py` works and doesn't require to install requirements that is the other way to solve this.
