### PR TITLE
INTERCEPT_REDIRECTS setting for debug-toolbar

### DIFF
--- a/project_name/settings/dev.py
+++ b/project_name/settings/dev.py
@@ -68,4 +68,8 @@ INTERNAL_IPS = ('127.0.0.1',)
 MIDDLEWARE_CLASSES += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
+
+DEBUG_TOOLBAR_CONFIG = {
+    'INTERCEPT_REDIRECTS': False,
+}
 ########## END TOOLBAR CONFIGURATION


### PR DESCRIPTION
When this setting is not set, admin panel won't run.
