### PR TITLE
add `COMPRESS_CSS_HASHING_METHOD` = 'content'

### DIFF
--- a/project_name/settings/common.py
+++ b/project_name/settings/common.py
@@ -263,6 +263,9 @@ WSGI_APPLICATION = 'wsgi.application'
 # See: http://django_compressor.readthedocs.org/en/latest/settings/#django.conf.settings.COMPRESS_ENABLED
 COMPRESS_ENABLED = True
 
+# See: http://django-compressor.readthedocs.org/en/latest/settings/#django.conf.settings.COMPRESS_CSS_HASHING_METHOD
+COMPRESS_CSS_HASHING_METHOD = 'content'
+
 # See: http://django_compressor.readthedocs.org/en/latest/settings/#django.conf.settings.COMPRESS_CSS_FILTERS
 COMPRESS_CSS_FILTERS = [
     'compressor.filters.template.TemplateFilter',


### PR DESCRIPTION
Like [suggested](http://django-compressor.readthedocs.org/en/latest/settings/#django.conf.settings.COMPRESS_CSS_HASHING_METHOD) for a configuration with multiple servers, we should set `COMPRESS_CSS_HASHING_METHOD` to 'content'

What do you think ?
